### PR TITLE
fix: custom tax lines in checkouts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.channelape</groupId>
 	<artifactId>shopify-sdk</artifactId>
-	<version>2.3.11</version>
+	<version>2.3.12</version>
 
 	<name>Shopify SDK</name>
 	<description>Java SDK for Shopify REST API.</description>

--- a/src/main/java/com/shopify/model/ShopifyShippingLine.java
+++ b/src/main/java/com/shopify/model/ShopifyShippingLine.java
@@ -47,7 +47,7 @@ public class ShopifyShippingLine {
 	@XmlElement(name = "validation_context")
 	private String validationContext;
 	@XmlElement(name = "custom_tax_lines")
-	private String customTaxLines;
+	private List<ShopifyTaxLine> customTaxLines;
 	private BigDecimal markup;
 	@XmlElement(name = "delivery_category")
 	private String deliveryCategory;

--- a/src/main/java/com/shopify/model/ShopifyTaxLine.java
+++ b/src/main/java/com/shopify/model/ShopifyTaxLine.java
@@ -19,7 +19,7 @@ public class ShopifyTaxLine {
 	@XmlElement(name = "price_set")
 	private PriceSet priceSet;
 
-	private long position;
+	private Long position;
 	private String source;
 	@XmlElement(name = "compare_at")
 	private BigDecimal compareAt;


### PR DESCRIPTION

stack trace:
```
com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.lang.String` out of START_ARRAY token
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 19177] (through reference chain: com.shopify.model.ShopifyCheckoutsRoot["checkouts"]->java.util.ArrayList[4]->com.shopify.model.ShopifyCheckout["shipping_lines"]->java.util.ArrayList[0]->com.shopify.model.ShopifyShippingLine["custom_tax_lines"])
```