### PR TITLE
bugfix/HEVO-14399/Add page size to Fulfillment order and erd coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>com.channelape</groupId>
 	<artifactId>shopify-sdk</artifactId>
-	<version>2.3.16</version>
+	<version>2.3.17</version>
 
 	<name>Shopify SDK</name>
 	<description>Java SDK for Shopify REST API.</description>

--- a/src/main/java/com/shopify/ShopifySdk.java
+++ b/src/main/java/com/shopify/ShopifySdk.java
@@ -1706,4 +1706,14 @@ public class ShopifySdk {
 	public ShopifyPage<ShopifyEvent> getDeletedPriceRules(DateTime fromDate, DateTime toDate, Integer pageSize, String pageInfo) {
 		return getDeletedEvents(fromDate, toDate, pageSize, pageInfo, PRICE_RULE);
 	}
+
+	public ShopifyFulfillmentOrders getFulfillmentOrders(String orderId, Integer pageSize) {
+		WebTarget webTarget = this.buildOrdersEndpoint().path(orderId).path("fulfillment_orders");
+		if (pageSize != null) {
+			webTarget.queryParam(LIMIT_QUERY_PARAMETER, pageSize);
+		}
+
+		return this.get(webTarget).readEntity(ShopifyFulfillmentOrders.class);
+	}
+
 }

--- a/src/main/java/com/shopify/model/FulfillmentHolds.java
+++ b/src/main/java/com/shopify/model/FulfillmentHolds.java
@@ -1,0 +1,19 @@
+package com.shopify.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class FulfillmentHolds {
+    private String reason;
+    @XmlElement(name = "reason_notes")
+    private String reasonNotes;
+}

--- a/src/main/java/com/shopify/model/ShopifyDeliveryMethod.java
+++ b/src/main/java/com/shopify/model/ShopifyDeliveryMethod.java
@@ -1,0 +1,29 @@
+package com.shopify.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import lombok.Data;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ShopifyDeliveryMethod {
+
+    @XmlElement(name = "id")
+    private Long id;
+
+    @XmlElement(name = "method_type")
+    private String methodType;
+
+    @XmlElement(name = "min_delivery_date_time")
+    private String minDeliveryDateTime;
+
+    @XmlElement(name = "max_delivery_date_time")
+    private String maxDeliveryDateTime;
+
+}

--- a/src/main/java/com/shopify/model/ShopifyFulfillmentOrder.java
+++ b/src/main/java/com/shopify/model/ShopifyFulfillmentOrder.java
@@ -33,4 +33,8 @@ public class ShopifyFulfillmentOrder {
     private ShopifyAddress assignedLocation;
     @XmlElement(name = "merchant_requests")
     private List<MerchantRequest> merchantRequests;
+    @XmlElement(name = "delivery_method")
+    private ShopifyDeliveryMethod deliveryMethod;
+    @XmlElement(name = "fulfill_by")
+    private String fulfillBy;
 }

--- a/src/main/java/com/shopify/model/ShopifyFulfillmentOrder.java
+++ b/src/main/java/com/shopify/model/ShopifyFulfillmentOrder.java
@@ -37,4 +37,6 @@ public class ShopifyFulfillmentOrder {
     private ShopifyDeliveryMethod deliveryMethod;
     @XmlElement(name = "fulfill_by")
     private String fulfillBy;
+    @XmlElement(name = "fulfillment_holds")
+    private List<FulfillmentHolds> fulfillmentHolds;
 }

--- a/src/main/java/com/shopify/model/ShopifyFulfillmentOrders.java
+++ b/src/main/java/com/shopify/model/ShopifyFulfillmentOrders.java
@@ -1,0 +1,21 @@
+package com.shopify.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.List;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@Data
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ShopifyFulfillmentOrders {
+
+    @JsonProperty("fulfillment_orders")
+    private List<ShopifyFulfillmentOrder> fulfillmentOrders;
+
+}


### PR DESCRIPTION
- Adding page size to fulfillment order and including changes present in shopify sdk2.
- ERD Coverage: Add fulfillment_holds to fulfillment_orders